### PR TITLE
IE8 - xml parser fixed

### DIFF
--- a/angular-xml.js
+++ b/angular-xml.js
@@ -25,7 +25,14 @@ if (typeof(angular) !== 'undefined') {
 
       MicrosoftXMLDOMParser.prototype.parse = function (input) {
         this.parser.async = false;
-        return this.parser.loadXML(input);
+        if (this.parser.loadXML(input))
+        {
+        	return this.parser;
+        }
+        else
+        {
+        	throw new Error('Cannot parse XML.');
+        }
       };
 
       function XMLDOMParser() {


### PR DESCRIPTION
parser.loadXML returns bool - Returns True if the XML load succeeded so you need to return whole parser. I have tested it right now. You can also simulate it in IE10 with IE8 doc/browser mode
See: http://msdn.microsoft.com/en-us/library/ms754585(v=vs.85).aspx
