### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Then there are 3 optoins:
 
 1. Download the latest tag.
 2. Use bower: `bower i --save angular-xml`
-3. Or use jsDelivr CDN: `//cdn.jsdelivr.net/angular.xml/2.2.1/angular-xml.min.js`
+3. Or use jsDelivr CDN: `//cdn.jsdelivr.net/npm/angular-xml@2.2.2/angular-xml.min.js`
 
 Contributing
 ------------


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-xml.

Feel free to ping me if you have any questions regarding this change.